### PR TITLE
Use new patterns-microos pattern names

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -90,7 +90,7 @@ textdomain="control"
 
         <selection_type config:type="symbol">auto</selection_type>
 
-        <default_patterns>MicroOS-base MicroOS-defaults MicroOS-hardware MicroOS-apparmor</default_patterns>
+        <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -227,7 +227,7 @@ textdomain="control"
         <id>container_host_role</id>
 
         <software>
-            <default_patterns>MicroOS-base MicroOS-defaults MicroOS-hardware MicroOS-apparmor container-runtime</default_patterns>
+            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
         </software>
 
         <order config:type="integer">200</order>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Apr 05 12:47:11 UTC 2019 - Richard Brown <rbrown@suse.de>
+
+- Use new patterns-microos pattern names
+- 20190405
+
+-------------------------------------------------------------------
 Wed Mar 13 15:03:53 UTC 2019 - Richard Brown <rbrown@suse.de>
 
 - Inital Version

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -117,7 +117,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20190313
+Version:        20190405
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
patterns-caasp is getting dropped, so we need to use the new patterns-microos pattern names to get Kubic through staging:H