### PR TITLE
Declare package manager patterns for each MicroOS role

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -78,7 +78,7 @@ textdomain="control"
 
         <selection_type config:type="symbol">auto</selection_type>
 
-        <default_patterns>microos_base microos_defaults microos_hardware</default_patterns>
+        <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -224,7 +224,7 @@ textdomain="control"
         <id>container_host_role</id>
 
         <software>
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_apparmor container_runtime</default_patterns>
         </software>
 
         <order config:type="integer">200</order>
@@ -242,7 +242,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
 	      <software>	
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor microos_gnome_desktop container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_apparmor microos_gnome_desktop container_runtime</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
@@ -349,7 +349,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
 	      <software>	
-            <default_patterns>microos_base microos_defaults microos_hardware microos_apparmor microos_kde_desktop container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_apparmor microos_kde_desktop container_runtime</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Feb 22 21:45:19 EST 2021 - Neal Gompa <ngompa13@gmail.com>
+
+- Declare package manager patterns for each MicroOS role (boo#1182803)
+- 20210222
+
+-------------------------------------------------------------------
 Thu Nov 26 13:21:56 CEST 2020 - Richard Brown <rbrown@suse.de>
 
 - Correct MicroOS Desktop Polkit rules (boo#1163453)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20201126
+Version:        20210222
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
The openSUSE MicroOS patterns are getting split up to support building MicroOS systems using either `transactional-update` (Zypper), Micro DNF (with txnupd plugin), or PackageKit (with txnupd plugin).

Reference: https://build.opensuse.org/request/show/874204