### PR TITLE
Set SELinux enforcing mode and use the new security proposal

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -603,6 +603,11 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>software</name>
                     <presentation_order>20</presentation_order>
                 </proposal_module>
+                <!-- Security proposal including firewall, CPU mitigation, SELinux and PolicyKit -->
+                <proposal_module>
+                    <name>security</name>
+                    <presentation_order>50</presentation_order>
+                </proposal_module>
             </proposal_modules>
         </proposal>
 

--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -70,6 +70,12 @@ textdomain="control"
         <!-- bnc #431158: Adjusts /etc/sysconfig/security/POLKIT_DEFAULT_PRIVS if set -->
         <polkit_default_privs>restrictive</polkit_default_privs>
 
+        <!-- Set SELinux enforcing mode by default -->
+        <selinux>
+          <mode>enforcing</mode>
+          <configurable config:type="boolean">true</configurable>
+          <pattern>microos_selinux</pattern>
+        </selinux>
     </globals>
 
     <software>

--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -75,7 +75,7 @@ textdomain="control"
           <mode>enforcing</mode>
           <configurable config:type="boolean">true</configurable>
           <!-- There are two SELinux patterns available, "selinux" and "microos_selinux".
-            The lastest has been chosen because its similarity with the one used on
+            The latest has been chosen because its similarity with the one used on
             SLE Micro, "microos-selinux" -->
           <pattern>microos_selinux</pattern>
         </selinux>

--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -646,8 +646,9 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>default_target</name>
                     <presentation_order>75</presentation_order>
                 </proposal_module>
+                <!-- Security proposal including firewall, CPU mitigation, SELinux and PolicyKit -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>50</presentation_order>
                 </proposal_module>
             </proposal_modules>
@@ -696,9 +697,9 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
                     <name>default_target</name>
                     <presentation_order>70</presentation_order>
                 </proposal_module>
-                <!-- FaTE #303859 - simple network (in fact firewall) cfg in 1st stage -->
+                <!-- Security proposal including firewall, CPU mitigation, SELinux and PolicyKit -->
                 <proposal_module>
-                    <name>firewall</name>
+                    <name>security</name>
                     <presentation_order>99</presentation_order>
                 </proposal_module>
                 <!-- Fate #319624 - proposal and dialog for existing SSH host keys -->

--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -74,6 +74,9 @@ textdomain="control"
         <selinux>
           <mode>enforcing</mode>
           <configurable config:type="boolean">true</configurable>
+          <!-- There are two SELinux patterns available, "selinux" and "microos_selinux".
+            The lastest has been chosen because its similarity with the one used on
+            SLE Micro, "microos-selinux" -->
           <pattern>microos_selinux</pattern>
         </selinux>
     </globals>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Mar  1 21:13:55 UTC 2021 - David Diaz <dgonzalez@suse.com>
+
+- Set SELinux enforcing mode by default (jsc#SMO-20) .
+- Use the new security proposal client (jsc#SLE-15840,
+  jsc#SLE-17307).
+- 20210303
+
+-------------------------------------------------------------------
 Mon Feb 22 21:45:19 EST 2021 - Neal Gompa <ngompa13@gmail.com>
 
 - Declare package manager patterns for each MicroOS role (boo#1182803)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20210222
+Version:        20210303
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
Related to  https://jira.suse.com/browse/SMO-20 and https://jira.suse.com/browse/SLE-17307 (internal links), sets SELinux as a major [**L**inux **S**ecurity **M**odule](https://www.kernel.org/doc/html/latest/admin-guide/LSM/index.html) using its _enforcing_ mode and replaces _firewall_ with the [new _security_ proposal client](https://github.com/yast/yast-installation/pull/906).

For openSUSE Tumbleweed, see https://github.com/yast/skelcd-control-openSUSE/pull/228
For SUSE MicroOS, see https://github.com/yast/skelcd-control-SMO/blob/SLE-15-SP2/control/control.SMO.xml

### :warning: Please review the chosen _SELinux pattern_ 

Looks like there are **two** SELinux patterns in available in openSUSE MicroOS:

![opensuse-microos-selinux](https://user-images.githubusercontent.com/1691872/109561341-f3fc8480-7ad4-11eb-9a27-b85284034d2a.png)

**_microos_selinux_** has been chosen just because in SMO the pattern is, in fact, [_microos-selinux_](https://github.com/yast/skelcd-control-SMO/pull/7/files#diff-03eac12fcbc17df72c9466fbfd2b9971366c130b06c62492d16723e46f41c567R85), with hyphen as word separator instead of an underscore.

Hard to know which is the right one here. Please, check it out.

---

To know more about SELinux proposal and the new security client, see https://github.com/yast/yast-security/pull/87 and https://github.com/yast/yast-installation/pull/906
