### PR TITLE
Fix SELinux patterns definition

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -77,7 +77,7 @@ textdomain="control"
           <!-- There are two SELinux patterns available, "selinux" and "microos_selinux".
             The latest has been chosen because its similarity with the one used on
             SLE Micro, "microos-selinux" -->
-          <pattern>microos_selinux</pattern>
+          <patterns>microos_selinux</patterns>
         </selinux>
     </globals>
 


### PR DESCRIPTION
Fix https://github.com/yast/skelcd-control-MicroOS/pull/30 using `<patterns>` element to define the SELinux patterns (see https://github.com/yast/yast-installation-control/pull/108).

https://ci.opensuse.org/job/yast-skelcd-control-MicroOS-master/24/console

