### PR TITLE
Enable COW on /home for Desktop (GNOME and KDE)

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -294,7 +294,6 @@ textdomain="control"
                     </subvolume>
                     <subvolume>
                         <path>home</path>
-                        <copy_on_write config:type="boolean">false</copy_on_write>
                     </subvolume>
                     <subvolume>
                         <path>opt</path>
@@ -401,7 +400,6 @@ textdomain="control"
                     </subvolume>
                     <subvolume>
                         <path>home</path>
-                        <copy_on_write config:type="boolean">false</copy_on_write>
                     </subvolume>
                     <subvolume>
                         <path>opt</path>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 22 23:28:11 CEST 2021 - Dario Faggioli <dfaggioli@suse.com>
+
+- Enable COW for /home on GNOME and KDE Desktop
+- 20210322
+
+-------------------------------------------------------------------
 Mon Mar  1 21:13:55 UTC 2021 - David Diaz <dgonzalez@suse.com>
 
 - Set SELinux enforcing mode by default (jsc#SMO-20) .

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20210303
+Version:        20210322
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
Having COW enabled is necessary for taking advantage of the coolest and
most advanced features of BTRFS. And some of these, such as compression
and checksuming, are particularly interesting and valuable for users'
data stored in /home directories.

Pretty much the one and only use case for having COW disabled on /home
is virtual machine run in QEMU user sessions. Libvirt deals with this
well (by basically doing something like `chattr +C` on the VM images
directory) since AFAICT version 6.6.

GNOME Boxes 3.38.2 flatpak (if installed in /home, with `--user`)
ships libvirt 6.1 _but_ the version currently available (and already
usable) in flathub-beta (version 40.beta) ships libvirt 6.7. In fact,
with the latter installed, I have (on a system installed with COW
enabled for /home):

dario@localhost:~> lsattr /
---------------C----- /etc
--------------------- /boot
--------------------- /home
--------------------- /opt
... ... ...

dario@localhost:~> lsattr .var/app/org.gnome.Boxes/data/gnome-boxes/
---------------C----- .var/app/org.gnome.Boxes/data/gnome-boxes/images

So, the only real roadblock against COW on /home will hopefully go away
soon, by default, for everyone (and while waiting for that, we can
document that a `chattr +C .var/app/.../images` is recommended).