### PR TITLE
Add bootloader pattern for all roles

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -95,7 +95,7 @@ textdomain="control"
 
         <selection_type config:type="symbol">auto</selection_type>
 
-        <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware</default_patterns>
+        <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware bootloader</default_patterns>
         <!-- bnc#876760: Explicitly selecting these (optional) patterns by default if they exist -->
         <optional_default_patterns>32bit</optional_default_patterns>
 
@@ -243,7 +243,7 @@ textdomain="control"
         <id>container_host_role</id>
 
         <software>
-            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware container_runtime bootloader</default_patterns>
         </software>
 
         <order config:type="integer">200</order>
@@ -261,7 +261,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
 	      <software>	
-            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_gnome_desktop container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_gnome_desktop container_runtime bootloader</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
@@ -367,7 +367,7 @@ textdomain="control"
           <network_manager>always</network_manager>
         </network>
 	      <software>	
-            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_kde_desktop container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_kde_desktop container_runtime bootloader</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
@@ -466,7 +466,7 @@ textdomain="control"
         <id>micro_os_role_ra_agent</id>
 
 	<software>
-          <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_ra_agent</default_patterns>
+          <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_ra_agent bootloader</default_patterns>
 	</software>
         <order config:type="integer">500</order>
         <additional_dialogs>inst_microos_role</additional_dialogs>
@@ -476,7 +476,7 @@ textdomain="control"
         <id>micro_os_role_ra_verifier</id>
 
 	<software>
-          <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_ra_verifier</default_patterns>
+          <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_ra_verifier bootloader</default_patterns>
 	</software>
         <order config:type="integer">600</order>
         <additional_dialogs>inst_microos_role</additional_dialogs>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Jan 24 21:12:31 UTC 2022 - David Diaz <dgonzalez@suse.com>
+
+- Add bootloader pattern for all roles (gh#yast/skelcd-control-MicroOS/#47).
+  Sent by Alberto Planas <aplanas@suse.com>.
+- 20220124
+
+-------------------------------------------------------------------
 Tue Dec 28 09:49:16 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Added 'lsm' section for selecting and configuring the desired

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20211228
+Version:        20220124
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
YaST will install all the packages that are resolved from the patterns
listed in the control.xml (for a selected role).  Internally also have
a list of packages that are installed that do not come from any
external requirement, for example the kernel or the Grub bootloader.

Since some time ago there is a pattern bootloader in the pattern-base
package, that can be used to explicitly drive an installation that
requires a bootloader.  This is an exercise to re-use the same
patterns for containers, that will not require a bootloader.

This patch makes explicit the requirement of the bootloader pattern.