### PR TITLE
Validate the built XML in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,19 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Prerequisites
-      run: rake build_dependencies:install
+      # use jing for validation instead of xmllint
+      run: |-
+        rake build_dependencies:install
+        zypper --non-interactive install --no-recommends jing
 
     # just for easier debugging...
     - name: Inspect Installed Packages
       run: rpm -qa | sort
+
+    # must be before the package build as it installs the /usr/lib/skelcd/CD1/control.xml
+    # which overwrites the original file from skelcd-control-openSUSE
+    - name: Validate XML
+      run:  rake test:validate
 
     - name: Package Build
       run: yast-ci-ruby -o package

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pot
+*.tar.bz2
+control/control.TWMicroOS.xml

--- a/README.md
+++ b/README.md
@@ -8,4 +8,29 @@ Installation control file for openSUSE MicroOS
 
 See also the [documentation for the `control.xml` file][1].
 
+
+## Building openSUSE Tumbleweed XML
+
+Run `rake build` to build the final `control/control.TWMicroOS.xml` file. By
+default it uses the base openSUSE Tumbleweed XML file from the
+`skelcd-control-openSUSE` package.
+
+That can be changed via the `OPENSUSE_CONTROL` environment variable to point to a Git
+checkout directly:
+``` shell
+OPENSUSE_CONTROL=../../skelcd-control-openSUSE/control/control.openSUSE.xml rake build
+```
+
+*Note: A relative path needs to be relative to the `control` subdirectory.*
+
+## Validation
+
+Run `rake test:validation` to validate the built XML file. It uses `jing` for
+XML validation, if that is not installed it fallbacks to `xmllint` (which
+unfortunately has a worse error reporting).
+
+You can use the `OPENSUSE_CONTROL` environment variable to set the base XML path,
+see above.
+
+
 [1]: https://github.com/yast/yast-installation/blob/master/doc/control-file.md

--- a/Rakefile
+++ b/Rakefile
@@ -51,7 +51,7 @@ file TARGET_XML => [ XSL_FILE, BASE_XML ] do
       "--output", TARGET_XML, XSL_FILE, BASE_XML
 end
 
-desc "Build the TWMicroOS XML (set the base SLES file via $BASE_XML, default: #{DEFAULT_OPENSUSE_CONTROL})"
+desc "Build the TWMicroOS XML (set the base XML file via $OPENSUSE_CONTROL, default: #{DEFAULT_OPENSUSE_CONTROL})"
 task :build => TARGET_XML.to_sym
 
 desc "Validate the built XML"

--- a/Rakefile
+++ b/Rakefile
@@ -32,3 +32,42 @@ namespace :version do
     File.write(spec_file, spec)
   end
 end
+
+CONTROL_SCHEMA = "/usr/share/YaST2/control/control.rng".freeze
+XSL_FILE = "control/control.MicroOS.xsl".freeze
+DEFAULT_OPENSUSE_CONTROL="/usr/lib/skelcd/CD1/control.xml"
+OPENSUSE_CONTROL = ENV["OPENSUSE_CONTROL"] || DEFAULT_OPENSUSE_CONTROL
+TARGET_XML = "control/control.TWMicroOS.xml".freeze
+BASE_XML = "control/control.MicroOS.xml"
+
+file TARGET_XML => [ XSL_FILE, BASE_XML ] do
+    # the location is relative to the input file, change the CWD so relative
+    # paths work correctly
+    Dir.chdir("control") do
+      abort "Missing file #{OPENSUSE_CONTROL}" unless File.exist?(OPENSUSE_CONTROL)
+    end
+
+    sh "xsltproc", "--stringparam", "openSUSE_control_file", OPENSUSE_CONTROL,
+      "--output", TARGET_XML, XSL_FILE, BASE_XML
+end
+
+desc "Build the TWMicroOS XML (set the base SLES file via $BASE_XML, default: #{DEFAULT_OPENSUSE_CONTROL})"
+task :build => TARGET_XML.to_sym
+
+desc "Validate the built XML"
+task :"test:validate" => TARGET_XML do
+  begin
+    # prefer using jing for validation
+    sh "jing", CONTROL_SCHEMA, TARGET_XML
+    puts "OK"
+  rescue Errno::ENOENT
+    # fallback to xmllint
+    sh "xmllint", "--noout", "--relaxng", CONTROL_SCHEMA, TARGET_XML
+  end
+end
+
+desc "Remove the generated XML file"
+task :clean do
+  rm TARGET_XML if File.exist?(TARGET_XML)
+end
+

--- a/control/control.MicroOS.xsl
+++ b/control/control.MicroOS.xsl
@@ -1,5 +1,5 @@
 <!--
-  Definition of the control.Kubic.xml -> control.TWKubic.xml transformation.
+  Definition of the control.MicroOS.xml -> control.TWMicroOS.xml transformation.
 -->
 
 <xsl:stylesheet version="1.0"
@@ -9,6 +9,9 @@
   xmlns="http://www.suse.com/1.0/yast2ns"
   exclude-result-prefixes="n"
 >
+
+  <!-- allow changing the input file with a command line parameter -->
+  <xsl:param name="openSUSE_control_file" select="'/usr/lib/skelcd/CD1/control.xml'"/>
 
   <xsl:output method="xml" indent="yes"/>
 
@@ -22,9 +25,7 @@
   <xsl:template match="n:software">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
-      <!-- Make sure this is the openSUSE control file!, try both (old and the new) locations -->
-      <xsl:copy-of select="document('/usr/lib/skelcd/CD1/control.xml')/*/n:software/n:extra_urls"/>
-      <xsl:copy-of select="document('/CD1/control.xml')/*/n:software/n:extra_urls"/>
+      <xsl:copy-of select="document($openSUSE_control_file)/*/n:software/n:extra_urls"/>
     </xsl:copy>
   </xsl:template>
 


### PR DESCRIPTION
- Similar to https://github.com/yast/skelcd-control-suse-manager-proxy/pull/20
- Validate the built XML in GitHub Actions
- See an [example run](https://github.com/yast/skelcd-control-MicroOS/runs/4597409118?check_suite_focus=true#step:6:5)
- Additionally allow using the base TW file from a Git checkout for running the validation locally