### PR TITLE
Use NetworkManager always (boo#1172684)

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -228,9 +228,7 @@ textdomain="control"
     </partitioning>
 
     <network>
-        <force_static_ip config:type="boolean">false</force_static_ip>
-        <network_manager>never</network_manager>
-        <startmode>auto</startmode>
+        <network_manager>always</network_manager>
         <ipv4_forward config:type="boolean">true</ipv4_forward>
         <ipv6_forward config:type="boolean">true</ipv6_forward>
     </network>
@@ -263,9 +261,6 @@ textdomain="control"
           <enable_kdump config:type="boolean">false</enable_kdump>
           <polkit_default_privs>standard</polkit_default_privs>
        </globals>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
 	      <software>	
             <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_gnome_desktop container_runtime bootloader</default_patterns>
         </software>
@@ -369,9 +364,6 @@ textdomain="control"
           <enable_kdump config:type="boolean">false</enable_kdump>
           <polkit_default_privs>standard</polkit_default_privs>
        </globals>
-        <network>
-          <network_manager>always</network_manager>
-        </network>
 	      <software>	
             <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_kde_desktop container_runtime bootloader</default_patterns>
         </software>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 04 09:23:32 UTC 2022 - Richard Brown <rbrown@suse.com>
+
+- Use NetworkManager always (boo#1172684)
+- 20220204
+
+-------------------------------------------------------------------
 Tue Jan 25 09:39:34 UTC 2022 - Alberto Planas Dominguez <aplanas@suse.com>
 
 - Remove ALPHA tag for the Keylime services

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20220125
+Version:        20220204
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
As with Tumbleweed - Wicked lacks caretaking in Tumbleweed and is just slow to boot.
NetworkManager is good enough also for most common server use cases
in Tumbleweed so let's just use one technology for all roles.

YaST anyway allows to switch to wicked in the proposal screen. So those
who know that they need for advanced cases wicked can still have it.