### PR TITLE
Enable recommends for MicroOS GNOME desktop

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -263,6 +263,7 @@ textdomain="control"
        </globals>
 	      <software>	
             <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_gnome_desktop container_runtime bootloader</default_patterns>
+            <install_recommended config:type="boolean">true</install_recommended>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 23 13:37:12 UTC 2022 - Frederic Crozat <fcrozat@suse.com>
+
+- Enable recommends for GNOME desktop system role
+- 20220223
+
+-------------------------------------------------------------------
 Fri Feb 04 09:23:32 UTC 2022 - Richard Brown <rbrown@suse.com>
 
 - Use NetworkManager always (boo#1172684)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20220204
+Version:        20220223
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
ensure language subpackages are installed by default