### PR TITLE
Change KDE desktop pattern to use transactional-update

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -364,7 +364,7 @@ textdomain="control"
           <polkit_default_privs>standard</polkit_default_privs>
        </globals>
 	      <software>
-            <default_patterns>microos_base microos_base_packagekit microos_defaults microos_hardware microos_kde_desktop container_runtime bootloader</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_kde_desktop container_runtime bootloader</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jul 25 15:14:00 UTC 2022 - Shawn W Dunn <sfalken@cloverleaf-linux.org>
+
+- Update MicroOS KDE Pattern to use transactional-update
+- 20220725
+
+-------------------------------------------------------------------
 Thu Jul 14 12:38:44 UTC 2022 - Richard Brown <rbrown@suse.com>
 
 - Restore KDE Desktop as Alpha (boo#1201049)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -118,7 +118,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20220714
+Version:        20220725
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION



## Problem

Change the MicroOS Desktop KDE pattern to use transactional-update, instead of packagekit

