### PR TITLE
Added "kdump" dependency

### DIFF
--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Jul 26 14:30:04 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "kdump" dependency, yast2-kdump only has a runtime
+  depenency but the package is also needed in the inst-sys
+  (related to bsc#1199840)
+- 20220726
+
+-------------------------------------------------------------------
 Mon Jul 25 15:14:00 UTC 2022 - Shawn W Dunn <sfalken@cloverleaf-linux.org>
 
 - Update MicroOS KDE Pattern to use transactional-update (boo#1201874)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -62,6 +62,8 @@ Requires:       yast2-firewall
 Requires:       yast2-installation >= 3.1.217.9
 Requires:       yast2-iscsi-client
 Requires:       yast2-kdump
+# yast2-kdump has only runtime dependency but the package is also needed in the inst-sys
+Requires:       kdump
 Requires:       yast2-multipath
 Requires:       yast2-network >= 3.1.42
 Requires:       yast2-nfs-client
@@ -118,7 +120,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20220725
+Version:        20220726
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
- Related to https://github.com/yast/yast-kdump/pull/128, `yast2-kdump` now uses a runtime dependency
- But we also need the `kdump` package in the inst-sys ([bsc#875765#c4](https://bugzilla.suse.com/show_bug.cgi?id=875765#c4))
- So add it explicitly here