### PR TITLE
Add inst_microos_role to Desktops (boo#1202067)

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -353,7 +353,8 @@ textdomain="control"
         </volumes>
         </partitioning>
 
-        <order config:type="integer">300</order>
+	<order config:type="integer">300</order>
+	<additional_dialogs>inst_microos_role</additional_dialogs>
       </system_role>
 
       <system_role>
@@ -456,7 +457,7 @@ textdomain="control"
         </partitioning>
 
         <order config:type="integer">400</order>
-        <additional_dialogs>inst_user_first</additional_dialogs>
+        <additional_dialogs>inst_microos_role inst_user_first</additional_dialogs>
       </system_role>
 
       <system_role>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 10 11:36:02 UTC 2022 - Richard Brown <rbrown@suse.com>
+
+- Added "inst_microos" role to Desktop roles (boo#1202067)
+- 20220810
+
+-------------------------------------------------------------------
 Tue Jul 26 14:30:04 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "kdump" dependency, yast2-kdump only has a runtime

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -120,7 +120,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20220726
+Version:        20220810
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
As discussed in boo#1202067, the desktops need NTP configuration too