### PR TITLE
Revert https://github.com/yast/skelcd-control-MicroOS/pull/57 partially,

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -457,7 +457,7 @@ textdomain="control"
         </partitioning>
 
         <order config:type="integer">400</order>
-        <additional_dialogs>inst_microos_role inst_user_first</additional_dialogs>
+        <additional_dialogs>inst_user_first</additional_dialogs>
       </system_role>
 
       <system_role>


### PR DESCRIPTION
for MicroOS Desktop KDE.   KDE Currently does not provide a mechanism
for creating a user on firstboot, like Gnome does.  (boo#1202852)


## Problem

With #57 the KDE Version of MicroOS Desktop is no longer easily installable, as in this use case, KDE does not provide a firstboot user creation mechanism like Gnome does.

- https://bugzilla.opensuse.org/show_bug.cgi?id=1202852

## Solution

Revert behavior of the Desktop Install roles for MicroOS Desktop KDE to prior behavior, until YaST2 can be changed, or KDE kiss https://github.com/KDE/kiss can be evaluated, packaged and tested, to provide firstboot user creation.


## Testing

- *Added a new unit test*
- *Tested manually*


## Screenshots

*If the fix affects the UI attach some screenshots here.*

