### PR TITLE
Fix syntax of additional_dialogs (boo#1202852)

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -457,7 +457,7 @@ textdomain="control"
         </partitioning>
 
         <order config:type="integer">400</order>
-        <additional_dialogs>inst_microos_role inst_user_first</additional_dialogs>
+        <additional_dialogs>inst_microos_role,inst_user_first</additional_dialogs>
       </system_role>
 
       <system_role>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 27 06:42:35 UTC 2022 - Fabian Vogt <fvogt@suse.com>
+
+- Fix syntax of additional_dialogs (boo#1202852)
+- 20221026
+
+-------------------------------------------------------------------
 Thu Sep 29 12:52:01 UTC 2022 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Disable kdump for %arm - boo#1203888

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -122,7 +122,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20221010
+Version:        20221026
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
Multiple modules are separated by commas.

https://bugzilla.suse.com/show_bug.cgi?id=1202852

YaST internal error is gone after this change.