### PR TITLE
Desktop-GNOME: Use easy polkit privs for best UX with NM, Hostname ch…

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -259,7 +259,7 @@ textdomain="control"
         
         <globals>
           <enable_kdump config:type="boolean">false</enable_kdump>
-          <polkit_default_privs>standard</polkit_default_privs>
+          <polkit_default_privs>easy</polkit_default_privs>
        </globals>
 	      <software>	
             <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_gnome_desktop container_runtime bootloader</default_patterns>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 27 14:25:35 UTC 2022 - Richard Brown <rbrown@suse.com>
+
+- Desktop-GNOME: Use easy polkit profile (boo#1204792)
+- 20221027
+
+-------------------------------------------------------------------
 Thu Oct 27 06:42:35 UTC 2022 - Fabian Vogt <fvogt@suse.com>
 
 - Fix syntax of additional_dialogs (boo#1202852)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -122,7 +122,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20221026
+Version:        20221027
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
…anging, etc


## Problem

MicroOS Desktop asks for the root password way too often for its users:

https://bugzilla.opensuse.org/show_bug.cgi?id=1204792

## Solution

The Easy profile exists for this case, so use it.

