### PR TITLE
Desktop-KDE: use easy polkit privs to normalize behavior with Gnome v…

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -362,7 +362,7 @@ textdomain="control"
 
         <globals>
           <enable_kdump config:type="boolean">false</enable_kdump>
-          <polkit_default_privs>standard</polkit_default_privs>
+          <polkit_default_privs>easy</polkit_default_privs>
        </globals>
 	      <software>
             <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_kde_desktop container_runtime bootloader</default_patterns>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Oct 27 14:50:49 UTC 2022 - Shawn W Dunn <sfalken@cloverleaf-linux.org>
+
+- Desktop-KDE: Changed polkit profile to match Gnome, for continuity
+
+-------------------------------------------------------------------
 Thu Oct 27 14:25:35 UTC 2022 - Richard Brown <rbrown@suse.com>
 
 - Desktop-GNOME: Use easy polkit profile (boo#1204792)


### PR DESCRIPTION
## Problem

MicroOS Desktop is asking for root password much too often, update the KDE default Policykit privileges to match the GNOME installation.

- https://bugzilla.opensuse.org/show_bug.cgi?id=1205348
- https://github.com/yast/skelcd-control-MicroOS/pull/64


## Solution

Adjust KDE Default Policykit privileges to match GNOME


