### PR TITLE
Add bugzilla reference to the latest changelog entry

### DIFF
--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -2,6 +2,7 @@
 Thu Oct 27 14:50:49 UTC 2022 - Shawn W Dunn <sfalken@cloverleaf-linux.org>
 
 - Desktop-KDE: Changed polkit profile to match Gnome, for continuity
+  (boo#1205348)
 - 20221205
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The latest changelog entry in #66 does not contain a bugzilla reference, making Jenkins sad.

* https://ci.opensuse.org/view/Yast/job/yast-skelcd-control-MicroOS-master/61/
* https://bugzilla.opensuse.org/show_bug.cgi?id=1205348

## Solution

Add the missing reference.