### PR TITLE
Set readonly_language to false for desktop roles (boo#1212560)

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -261,8 +261,9 @@ textdomain="control"
         <globals>
           <enable_kdump config:type="boolean">false</enable_kdump>
           <polkit_default_privs>easy</polkit_default_privs>
-       </globals>
-	      <software>	
+          <readonly_language config:type="boolean">false</readonly_language>
+        </globals>
+        <software>
             <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_gnome_desktop container_runtime</default_patterns>
         </software>
         <partitioning>
@@ -364,8 +365,9 @@ textdomain="control"
         <globals>
           <enable_kdump config:type="boolean">false</enable_kdump>
           <polkit_default_privs>easy</polkit_default_privs>
-       </globals>
-	      <software>
+          <readonly_language config:type="boolean">false</readonly_language>
+        </globals>
+        <software>
             <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_kde_desktop container_runtime</default_patterns>
         </software>
         <partitioning>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Sep 12 12:04:40 UTC 2023 - Fabian Vogt <fvogt@suse.com>
+
+- Set readonly_language to false for desktop roles (boo#1212560)
+- 20230912
+
+-------------------------------------------------------------------
 Wed May 24 15:55:44 UTC 2023 - Stefan Schubert <schubi@suse.com>
 
 - Removed bootloader from default patterns. (jsc#PED-1906)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -122,7 +122,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20230524
+Version:        20230912
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
Desktops are multilingual, unlike the "plain" MicroOS roles.