### PR TITLE
Update definitions for Aeon/Kalpa

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -566,10 +566,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
 	</container_host_role_description>
         <micro_os_gnome_desktop_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>MicroOS Desktop (GNOME) [RC]</label>
+          <label>openSUSE Aeon (Gnome) [RC]</label>
         </micro_os_gnome_desktop_role>
         <micro_os_gnome_desktop_role_description>
-          <label>• MicroOS Desktop with automatic updates and rollback
+          <label>• openSUSE Aeon offering the GNOME Desktop built on MicroOS
 • Install Apps using `Software`
 • Includes Podman Container Runtime by default</label>
         </micro_os_gnome_desktop_role_description>
@@ -594,10 +594,10 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
 	</micro_os_role_ra_verifier_description>
 	<micro_os_kde_desktop_role>
           <!-- TRANSLATORS: a label for a system role -->
-          <label>MicroOS Desktop (KDE Plasma) [ALPHA]</label>
+          <label>openSUSE Kalpa (Plasma) [ALPHA]</label>
         </micro_os_kde_desktop_role>
         <micro_os_kde_desktop_role_description>
-          <label>• MicroOS Desktop with automatic updates and rollback
+          <label>• openSUSE Kalpa offering the KDE Plasma Desktop built on MicroOS
 • Install Apps using `Discover`
 • Includes Podman Container Runtime by default</label>
         </micro_os_kde_desktop_role_description>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Sat Feb 03 18:35:00 UTC 2024 - Shawn W Dunn <sfalken@opensuse.org>
+
+- Modified the Naming for the Desktop versions (Aeon/Kalpa) to
+  align more closely with the new branding.   Temporary until we
+  our new brand specific installation images ready.
+- 20240203
+
+-------------------------------------------------------------------
 Tue Sep 12 12:04:40 UTC 2023 - Fabian Vogt <fvogt@suse.com>
 
 - Set readonly_language to false for desktop roles (boo#1212560)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -122,7 +122,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20230912
+Version:        20240203
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

The current MicroOS ISO Installer still reflects the deprecated "MicroOS Desktop" naming for the Desktop variants

- https://bugzilla.opensuse.org/show_bug.cgi?id=1219526



## Solution

Update the wording in the Yast installer to reflect the Proper branding for Aeon and Kalpa (Gnome and KDE, respectively), to reduce confusion in the community, while we work on our Branding specific installers.


