### PR TITLE
Remove MicroOS GNOME Desktop/Aeon

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -258,112 +258,6 @@ textdomain="control"
       </system_role>
 
       <system_role>
-        <id>micro_os_gnome_desktop_role</id>
-        
-        <globals>
-          <enable_kdump config:type="boolean">false</enable_kdump>
-          <polkit_default_privs>easy</polkit_default_privs>
-          <readonly_language config:type="boolean">false</readonly_language>
-        </globals>
-        <software>
-            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_gnome_desktop container_runtime</default_patterns>
-        </software>
-        <partitioning>
-        <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>
-
-        <proposal>
-            <lvm config:type="boolean">false</lvm>
-            <encryption_method>luks2</encryption_method>
-            <encryption_pbkdf>pbkdf2</encryption_pbkdf>
-            <windows_delete_mode config:type="symbol">all</windows_delete_mode>
-            <linux_delete_mode config:type="symbol">all</linux_delete_mode>
-            <other_delete_mode config:type="symbol">all</other_delete_mode>
-        </proposal>
-
-        <volumes config:type="list">
-            <!-- The / filesystem -->
-            <volume>
-                <mount_point>/</mount_point>
-                <!-- Default == final, since the user can't change it -->
-                <fs_type>btrfs</fs_type>
-                <desired_size config:type="disksize">20 GiB</desired_size>
-                <min_size config:type="disksize">5 GiB</min_size>
-                <max_size config:type="disksize">unlimited</max_size>
-                <weight config:type="integer">20</weight>
-                <!-- Always use snapshots, no matter what -->
-                <snapshots config:type="boolean">true</snapshots>
-                <snapshots_configurable config:type="boolean">false</snapshots_configurable>
-
-                <!-- You don't want to miss the / volume -->
-                <proposed_configurable config:type="boolean">false</proposed_configurable>
-
-                <!-- the default subvolume "@" was requested by product management -->
-                <btrfs_default_subvolume>@</btrfs_default_subvolume>
-                <!-- root filesystem should be read-only -->
-                <btrfs_read_only config:type="boolean">true</btrfs_read_only>
-
-                <!-- Subvolumes to be created for a Btrfs root file system -->
-                <!-- copy_on_write is true by default -->
-                <!-- The XML parser is very simplistic, thus not using attributes, but sub-elements -->
-                <subvolumes config:type="list">
-                    <subvolume>
-                        <path>root</path>
-                    </subvolume>
-                    <subvolume>
-                        <path>home</path>
-                    </subvolume>
-                    <subvolume>
-                        <path>opt</path>
-                    </subvolume>
-                    <subvolume>
-                        <path>srv</path>
-                    </subvolume>
-		    <subvolume>                                                                                      
-                        <path>boot/writable</path>                                                                   
-                    </subvolume>                                                                                     
-                    <subvolume>                                                                                      
-                        <path>usr/local</path>                                                                       
-                    </subvolume>
-                    <!-- unified var subvolume - https://lists.opensuse.org/opensuse-packaging/2017-11/msg00017.html -->
-                    <subvolume>
-                        <path>var</path>
-                        <copy_on_write config:type="boolean">false</copy_on_write>
-                    </subvolume>
-
-                    <!-- architecture specific subvolumes -->
-
-                    <subvolume>
-                        <path>boot/grub2/arm64-efi</path>
-                        <archs>aarch64</archs>
-                    </subvolume>
-                    <subvolume>
-                        <path>boot/grub2/i386-pc</path>
-                        <archs>x86_64</archs>
-                    </subvolume>
-                    <subvolume>
-                        <path>boot/grub2/powerpc-ieee1275</path>
-                        <archs>ppc,!board_powernv</archs>
-                    </subvolume>
-                    <subvolume>
-                        <path>boot/grub2/s390x-emu</path>
-                        <archs>s390</archs>
-                    </subvolume>
-                    <subvolume>
-                        <path>boot/grub2/x86_64-efi</path>
-                        <archs>x86_64</archs>
-                    </subvolume>
-                </subvolumes>
-            </volume>
-
-            <!-- No swap partition is defined, so it's never created -->
-        </volumes>
-        </partitioning>
-
-	<order config:type="integer">300</order>
-	<additional_dialogs>inst_microos_role</additional_dialogs>
-      </system_role>
-
-      <system_role>
         <id>micro_os_kde_desktop_role</id>
 
         <globals>
@@ -570,15 +464,6 @@ configured accordingly to match the use case of the role. &lt;/p&gt;</label>
           <label>• MicroOS optimised for hosting container workloads
 • Includes Podman Container Runtime by default</label>
 	</container_host_role_description>
-        <micro_os_gnome_desktop_role>
-          <!-- TRANSLATORS: a label for a system role -->
-          <label>openSUSE Aeon (Gnome) [RC]</label>
-        </micro_os_gnome_desktop_role>
-        <micro_os_gnome_desktop_role_description>
-          <label>• openSUSE Aeon offering the GNOME Desktop built on MicroOS
-• Install Apps using `Software`
-• Includes Podman Container Runtime by default</label>
-        </micro_os_gnome_desktop_role_description>
         <micro_os_role_ra_agent>
           <!-- TRANSLATORS: a label for a system role -->
           <label>MicroOS with Remote Attestation (Agent)</label>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 27 17:03:13 UTC 2024 - Richard Brown <rbrown@suse.com>
+
+- Remove MicroOS GNOME Desktop/Aeon, now installed via own media
+- 20240527
+
+-------------------------------------------------------------------
 Thu May 16 12:02:14 UTC 2024 - Ludwig Nussel <lnussel@suse.com>
 
 - Enable LUKS2 and PBKDF2 by default for compat with grub (boo#1185291)

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -122,7 +122,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20240524
+Version:        20240527
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
## Problem

Aeon (formerly MicroOS GNOME Desktop) no longer should be installed via MicroOS media

## Solution

Remove the system role from the MicroOS Media

## Testing

- *Tested manually*

