### PR TITLE
Using tpm2 as default

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -129,7 +129,7 @@ textdomain="control"
             <lvm config:type="boolean">false</lvm>
             <encryption_method>systemd_fde</encryption_method>
             <encryption_pbkdf>argon2id</encryption_pbkdf>
-            <encryption_authentication>tpm2+pin</encryption_authentication>
+            <encryption_authentication>tpm2</encryption_authentication>
             <windows_delete_mode config:type="symbol">all</windows_delete_mode>
             <linux_delete_mode config:type="symbol">all</linux_delete_mode>
             <other_delete_mode config:type="symbol">all</other_delete_mode>
@@ -276,7 +276,7 @@ textdomain="control"
             <lvm config:type="boolean">false</lvm>
             <encryption_method>systemd_fde</encryption_method>
             <encryption_pbkdf>argon2id</encryption_pbkdf>
-            <encryption_authentication>tpm2+pin</encryption_authentication>
+            <encryption_authentication>tpm2</encryption_authentication>
             <windows_delete_mode config:type="symbol">all</windows_delete_mode>
             <linux_delete_mode config:type="symbol">all</linux_delete_mode>
             <other_delete_mode config:type="symbol">all</other_delete_mode>

--- a/package/skelcd-control-MicroOS.changes
+++ b/package/skelcd-control-MicroOS.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 23 14:39:22 UTC 2025 - Stefan Schubert <schubi@suse.de>
+
+- Using tpm2 instead of tpm2+pin because MicroOS will installed
+  mainly on servers. (jsc#PED-10703)
+- 20250723
+
+-------------------------------------------------------------------
 Wed Jul 16 10:11:51 UTC 2025 - Stefan Schubert <schubi@suse.de>
 
 - Using systemd_fde in partition proposal (jsc#PED-10703).

--- a/package/skelcd-control-MicroOS.spec
+++ b/package/skelcd-control-MicroOS.spec
@@ -121,7 +121,7 @@ Requires:       yast2-vm
 
 Url:            https://github.com/yast/skelcd-control-MicroOS
 AutoReqProv:    off
-Version:        20250716
+Version:        20250723
 Release:        0
 Summary:        The MicroOS control file needed for installation
 License:        MIT


### PR DESCRIPTION
Using tpm2 instead of tpm2+pin because MicroOS will installed
mainly on servers. So there will not be a user who can provide a pin manually.
