### PR TITLE
Reference container_runtime_podman instead of the unspecific alias

### DIFF
--- a/control/control.MicroOS.xml
+++ b/control/control.MicroOS.xml
@@ -251,7 +251,7 @@ textdomain="control"
         <id>container_host_role</id>
 
         <software>
-            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware container_runtime_podman</default_patterns>
         </software>
 
         <order config:type="integer">200</order>
@@ -267,7 +267,7 @@ textdomain="control"
           <readonly_language config:type="boolean">false</readonly_language>
         </globals>
         <software>
-            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_kde_desktop container_runtime</default_patterns>
+            <default_patterns>microos_base microos_base_zypper microos_defaults microos_hardware microos_kde_desktop container_runtime_podman</default_patterns>
         </software>
         <partitioning>
         <expert_partitioner_warning config:type="boolean">true</expert_partitioner_warning>


### PR DESCRIPTION
## Problem

Relates to https://build.opensuse.org/requests/1350942/changes
The pattern is corrected to only provide one name `container_runtime_podman`

## Solution

Reference the correct name of the pattern


